### PR TITLE
fix: make ${PROJECT_DIR} relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ $ nx semantic-release app-c --repositoryUrl "https://github.com/goestav/nx-seman
 
 | Token            | Expands into                                                                                  |
 | ---------------- | --------------------------------------------------------------------------------------------- |
-| ${PROJECT_DIR}   | Resolves to the current project direcory (ex. `/Users/theunderscorer/nx-monorepo/apps/app-a`) |
+| ${PROJECT_DIR}   | Resolves to the current project direcory (ex. `apps/app-a`) |
 | ${PROJECT_NAME}  | Resolves to the current project name (ex. `app-a`)                                            |
 | ${WORKSPACE_DIR} | Resolves to the current workspace direcory (ex. `/Users/theunderscorer/nx-monorepo`)          |
 

--- a/packages/nx-semantic-release/src/executors/semantic-release/semantic-release.ts
+++ b/packages/nx-semantic-release/src/executors/semantic-release/semantic-release.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import {
   ExecutorContext,
   parseTargetString,
@@ -139,7 +140,7 @@ export function resolveOptions(
 
   return applyTokensToSemanticReleaseOptions(mergedOptions, {
     projectName: context.projectName as string,
-    projectDir: getDefaultProjectRoot(context),
+    projectDir: path.relative(context.cwd, getDefaultProjectRoot(context)),
     workspaceDir: workspaceRoot,
   });
 }


### PR DESCRIPTION
With this fix, it will be possible to do the following things:
```json
{
  "outputPath": "${WORKSPACE_DIR}/dist/${PROJECT_DIR}",
}
```